### PR TITLE
Update docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install joi-currency-code
 ## Usage
 
 ```javascript
-const Joi = require('joi-currency-code')(require('@hapi/joi'));
+const Joi = require('@hapi/joi').extend(require('joi-currency-code'));
 
 const schema = Joi.object({
   code: Joi.string().currency()


### PR DESCRIPTION
When using this module for `@hapi/joi`, I found that this was the only reliable way to extend `Joi`.